### PR TITLE
Iden

### DIFF
--- a/rating.class.php
+++ b/rating.class.php
@@ -24,6 +24,7 @@ class Rating
     private $countNotNullVotes; //count of votes more than 0
     private $currentRatingValue; //rating of current element
     private $amendment = 10; //statistic amendment
+    private $old_rate = [];
 
     public function __construct($table, $elemList, $allRatings, $voteMaxLive, $minVotesCount)
     {
@@ -39,7 +40,10 @@ class Rating
     {
         for ($i = 0; $i < count($this->elems); $i++) {
             if ($this->elems[$i]['elemId'] == $elemId) {
-                $this->getOldRating($i);
+                if(!array_key_exists($i,$this->old_rate)){
+                    $this->getOldRating($i);
+                    $this->old_rate[$i]=1;
+                }
                 switch ($rating) {
                     case '0':
                         return $this->elems[$i]['zeroStarsCount'];


### PR DESCRIPTION
- баг со срединим рейтингом в getCount

при вызове getCount на однои и том-же elemId старый рейтинг пересчитывается заново при каждом запросе.
То есть если его запросить 1 раз  - все оке, но если сперва pапросить любой другой рейтинг у этого элемента, то при повторном обращении рейтинг будет не правильный.